### PR TITLE
Fail domain authentication validation if response body has valid:false

### DIFF
--- a/sdk/errors.go
+++ b/sdk/errors.go
@@ -43,9 +43,6 @@ var (
 	// ErrFailedCreatingSubUser error displayed when the provider can not create a subuser.
 	ErrFailedCreatingSubUser = errors.New("failed creating subUser")
 
-	// ErrFailedDeletingSubUser error displayed when the provider can not delete a subuser.
-	ErrFailedDeletingSubUser = errors.New("failed deleting subUser")
-
 	// ErrTemplateIDRequired error displayed when a template ID wasn't specified.
 	ErrTemplateIDRequired = errors.New("a template ID is required")
 
@@ -82,6 +79,8 @@ var (
 	ErrDomainAuthenticationIDRequired = errors.New("id for domain authentication is required")
 
 	ErrFailedDeletingDomainAuthentication = errors.New("failed deleting domain authentication")
+
+	ErrDomainAuthenticationValidationFailed = errors.New("domain authentication validation failed")
 
 	ErrLinkBrandingIDRequired = errors.New("link branding id is required")
 

--- a/sendgrid/resource_sendgrid_domain_authentication_validation.go
+++ b/sendgrid/resource_sendgrid_domain_authentication_validation.go
@@ -20,6 +20,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
+// https://docs.sendgrid.com/api-reference/domain-authentication/validate-a-domain-authentication
 func resourceSendgridDomainAuthenticationValidation() *schema.Resource { //nolint:funlen
 	return &schema.Resource{
 		CreateContext: resourceSendgridDomainAuthenticationValidationCreate,
@@ -93,10 +94,6 @@ func resourceSendgridDomainAuthenticationValidationUpdate(
 	return validateDomain(ctx, d, m)
 }
 
-func resourceSendgridDomainAuthenticationValidationDelete(
-	ctx context.Context,
-	d *schema.ResourceData,
-	m interface{},
-) diag.Diagnostics {
+func resourceSendgridDomainAuthenticationValidationDelete(context.Context, *schema.ResourceData, interface{}) diag.Diagnostics {
 	return nil
 }


### PR DESCRIPTION
### Before this change
* At present, we only check the status code of the response from SendGrid API. However SendGrid API can return 200 OK but with an error in the response body. Hence the terraform resource `sendgrid_domain_authentication_validation` will be considered as created successfully even if the SendGrid API responded with `"valid":false` in the response. 
* We saw this happen while [testing in the Sandbox kraken account](https://app.terraform.io/app/octopus/workspaces/sandbox-kraken-test/runs/run-hRYZcEetpZy7Heia) where we expected the create of the `sendgrid_domain_authentication_validation` to fail, but it did not. 
* At present, the [data http check is accounting for this API behaviour](https://github.com/octoenergy/terraform-aws-sendgrid/blob/e4ef675c86c806d4b0ace2847dbbd0a100cf8c9b/main.tf#L98) (Kudos @orf)
* API Ref: https://docs.sendgrid.com/api-reference/domain-authentication/validate-a-domain-authentication


### After this change
We check if the response body states `"valid":true` and return an err otherwise. This would make the Terraform resource creation step to fail correctly. 


#### Other minor refactoring
* Remove unused ErrFailedDeletingSubUser
* Remove names for unused params
