### PR TITLE
[Feat] Link branding validation

### DIFF
--- a/docs/resources/link_branding_validation.md
+++ b/docs/resources/link_branding_validation.md
@@ -1,0 +1,26 @@
+# sendgrid_link_branding_validation
+
+Provide a resource to manage a link branding validation.
+
+## Example Usage
+
+```hcl
+
+	resource "sendgrid_link_branding_validation" "foo" {
+		link_branding_id = sendgrid_link_branding.foo.id
+	}
+
+```
+
+## Argument Reference
+
+The following arguments are supported:
+
+* `link_branding_id` - (Required) Id of the link branding to validate.
+
+## Attributes Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `valid` - Indicates if this is a valid link branding or not.
+

--- a/sendgrid/provider.go
+++ b/sendgrid/provider.go
@@ -91,6 +91,7 @@ func Provider() *schema.Provider {
 			"sendgrid_domain_authentication":            resourceSendgridDomainAuthentication(),
 			"sendgrid_domain_authentication_validation": resourceSendgridDomainAuthenticationValidation(),
 			"sendgrid_link_branding":                    resourceSendgridLinkBranding(),
+			"sendgrid_link_branding_validation":         resourceSendgridLinkBrandingValidation(),
 			"sendgrid_sso_integration":                  resourceSendgridSSOIntegration(),
 			"sendgrid_sso_certificate":                  resourceSendgridSSOCertificate(),
 			"sendgrid_teammate":                         resourceSendgridTeammate(),

--- a/sendgrid/resource_sendgrid_link_branding_validation.go
+++ b/sendgrid/resource_sendgrid_link_branding_validation.go
@@ -1,0 +1,99 @@
+/*
+Provide a resource to manage a link branding validation.
+Example Usage
+```hcl
+
+	resource "sendgrid_link_branding_validation" "foo" {
+		link_branding_id = sendgrid_link_branding.foo.id
+	}
+
+```
+*/
+package sendgrid
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	sendgrid "github.com/octoenergy/terraform-provider-sendgrid/sdk"
+)
+
+// https://docs.sendgrid.com/api-reference/link-branding/validate-a-branded-link
+func resourceSendgridLinkBrandingValidation() *schema.Resource { //nolint:funlen
+	return &schema.Resource{
+		CreateContext: resourceSendgridLinkBrandingValidationCreate,
+		ReadContext:   resourceSendgridLinkBrandingValidationRead,
+		UpdateContext: resourceSendgridLinkBrandingValidationUpdate,
+		DeleteContext: resourceSendgridLinkBrandingValidationDelete,
+		Importer: &schema.ResourceImporter{
+			StateContext: schema.ImportStatePassthroughContext,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"link_branding_id": {
+				Type:        schema.TypeString,
+				Description: "Id of the link branding to validate.",
+				Required:    true,
+			},
+
+			"valid": {
+				Type:        schema.TypeBool,
+				Description: "Indicates if this is a valid link branding or not.",
+				Computed:    true,
+			},
+		},
+	}
+}
+
+func resourceSendgridLinkBrandingValidationCreate(
+	ctx context.Context,
+	d *schema.ResourceData,
+	m interface{},
+) diag.Diagnostics {
+	return validateLinkBranding(ctx, d, m)
+}
+
+func validateLinkBranding(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+	c := m.(*sendgrid.Client)
+
+	if err := c.ValidateLinkBranding(ctx, d.Get("link_branding_id").(string)); err.Err != nil || err.StatusCode != 200 {
+		if err.Err != nil {
+			return diag.FromErr(err.Err)
+		}
+		return diag.Errorf("unable to validate domain DNS configuration")
+	}
+
+	return resourceSendgridLinkBrandingValidationRead(ctx, d, m)
+}
+
+func resourceSendgridLinkBrandingValidationRead( //nolint:funlen,cyclop
+	ctx context.Context,
+	d *schema.ResourceData,
+	m interface{},
+) diag.Diagnostics {
+	c := m.(*sendgrid.Client)
+
+	link, err := c.ReadLinkBranding(ctx, d.Get("link_branding_id").(string))
+	if err.Err != nil {
+		return diag.FromErr(err.Err)
+	}
+
+	//nolint:errcheck
+	d.Set("valid", link.Valid)
+	d.SetId(fmt.Sprint(link.ID))
+	return nil
+}
+
+func resourceSendgridLinkBrandingValidationUpdate(
+	ctx context.Context,
+	d *schema.ResourceData,
+	m interface{},
+) diag.Diagnostics {
+	return validateLinkBranding(ctx, d, m)
+}
+
+func resourceSendgridLinkBrandingValidationDelete(context.Context, *schema.ResourceData, interface{}) diag.Diagnostics {
+	return nil
+}


### PR DESCRIPTION
This is the same type of resource as the new `sendgrid_domain_authentication_validation`.
Link branding uses a different REST endpoint, so this new resource should hit the right REST endpoint for validation. 