### PR TITLE
Remove ForceNew on custom dkim selector

### DIFF
--- a/sendgrid/resource_sendgrid_domain_authentication.go
+++ b/sendgrid/resource_sendgrid_domain_authentication.go
@@ -87,7 +87,6 @@ func resourceSendgridDomainAuthentication() *schema.Resource { //nolint:funlen
 				Type:        schema.TypeString,
 				Description: "Add a custom DKIM selector. Accepts three letters or numbers.",
 				Optional:    true,
-				ForceNew:    true,
 			},
 			"valid": {
 				Type:        schema.TypeBool,


### PR DESCRIPTION
See https://github.com/octoenergy/platform-engineering/issues/4195

`ForceNew` was causing recreations of domain authentication resource and associated DNS CNAME records on every run for any stack using the `custom_dkim_selector` module argument.

`ForceNew` shouldn't be necessary as the domain authentication resources shouldn't change after creation without manual configuration changes.

Test showing sendgrid resources no longer recreating: https://spacelift.ktl.net/stack/oegb-kraken-prod/run/01JWRJF6D1D9G3ASBMFE5A3ZPE