### PR TITLE
Handle SendGrid link branding 404 response

### DIFF
--- a/sdk/link_branding.go
+++ b/sdk/link_branding.go
@@ -84,10 +84,10 @@ func (c *Client) ReadLinkBranding(ctx context.Context, id string) (*LinkBranding
 		}
 	}
 
-	respBody, _, err := c.Get(ctx, "GET", "/whitelabel/links/"+id)
+	respBody, statusCode, err := c.Get(ctx, "GET", "/whitelabel/links/"+id)
 	if err != nil {
 		return nil, RequestError{
-			StatusCode: http.StatusInternalServerError,
+			StatusCode: statusCode,
 			Err:        err,
 		}
 	}

--- a/sendgrid/resource_sendgrid_link_branding.go
+++ b/sendgrid/resource_sendgrid_link_branding.go
@@ -127,6 +127,11 @@ func resourceSendgridLinkBrandingRead(ctx context.Context, d *schema.ResourceDat
 
 	link, err := c.ReadLinkBranding(ctx, d.Id())
 	if err.Err != nil {
+		if err.StatusCode == 404 {
+			// Resource was deleted outside of Terraform
+			d.SetId("")
+			return nil
+		}
 		return diag.FromErr(err.Err)
 	}
 


### PR DESCRIPTION
⚠️  Written by Claude, but it makes sense to me, and I don't know how others haven't run into this error based on the [original repo](https://github.com/arslanbekov/terraform-provider-sendgrid/blob/master/sendgrid/resource_sendgrid_link_branding.go#L132)? ⚠️ 

Trying to fix [this error](https://spacelift.ktl.net/stack/tokyogas-kraken-test/run/01KFMHMYQA75S5PJ0TJYE5XED7):
```
│ Error: api response: HTTP 404: {"errors":[{"message":"Branded link not found."}]}
│ , err: <nil>
│ 
│   with module.sendgrid.sendgrid_link_branding_validation.this,
│   on .terraform/modules/sendgrid/main.tf line 18, in resource "sendgrid_link_branding_validation" "this":
│   18: resource "sendgrid_link_branding_validation" "this" {
```

Which errors at the _planning_ stage, so Terraform doesn't even try and restore the link branding :/ 

Deleting the resource from state gets around the error, and TF creates the resource, so I'm fairly sure this will solve the issue